### PR TITLE
Updated to fedora:24 so can use correct copr repo

### DIFF
--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:25
+FROM fedora:24
 
 LABEL Name="quiver" \
     Vendor="ssorj/Justin Ross" \
-    Version="1.0.0" \
+    Version="1.0.1" \
     License="Apache License, Version 2.0"
 
 # Core dependancies
@@ -14,8 +14,17 @@ RUN dnf install -y qpid-proton-c-devel qpid-cpp-client-devel qpid-proton-cpp-dev
      dnf clean all
 
 # Quiver
-RUN curl https://copr.fedorainfracloud.org/coprs/jross/ssorj/repo/epel-7/jross-ssorj-epel-7.repo -o /etc/yum.repos.d/jross-ssorj-epel-7.repo && \
+RUN dnf install -y dnf-plugins-core && \
+     dnf copr enable -y jross/ssorj && \
      dnf install -y quiver && \
      dnf clean all
+
+ADD fix-permissions /fix-permissions
+
+# Fix folder permissions
+RUN chmod +x /fix-permissions && \
+     mkdir /.vertx && \
+     /fix-permissions /usr/lib/quiver && \
+     /fix-permissions /.vertx
 
 CMD ["quiver", "--help"]

--- a/openshift/fix-permissions
+++ b/openshift/fix-permissions
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Fix permissions on the given directory to allow group read/write of
+# regular files and execute of directories.
+#
+# https://github.com/openshift/jenkins/blob/master/1/contrib/jenkins/fix-permissions
+
+find $1 -exec chgrp 0 {} \;
+find $1 -exec chmod g+rw {} \;
+find $1 -type d -exec chmod g+x {} +

--- a/openshift/openshift-support-template.yml
+++ b/openshift/openshift-support-template.yml
@@ -16,6 +16,14 @@ objects:
   spec:
     tags:
     - annotations:
+        openshift.io/imported-from: fedora:24
+      from:
+        kind: DockerImage
+        name: fedora:24
+      generation: 2
+      importPolicy: {}
+      name: "24"
+    - annotations:
         openshift.io/imported-from: fedora:25
       from:
         kind: DockerImage
@@ -52,7 +60,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: fedora:25
+          name: fedora:24
       type: Docker
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
- Added fix permissions as vertx was unable to create cache directory
- Changed to fedora 24 so can use copr
- Changed to use coprs via dnf