### PR TITLE
Fix C++ arrow in peer-to-peer mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ TARGETS += \
 endif
 
 CCFLAGS := -Os -std=c++11 -lstdc++
-CFLAGS  := -g -Os
+CFLAGS  := -Os
 
 .PHONY: default
 default: devel

--- a/exec/quiver-arrow-qpid-proton-c.c
+++ b/exec/quiver-arrow-qpid-proton-c.c
@@ -291,9 +291,10 @@ static bool handle(struct arrow* a, pn_event_t* e) {
         break;
     }
     case PN_TRANSPORT_CLOSED:
-        /* TODO aconway 2017-06-12: ignoring transport errors from dummy connections used ot 
-           probe to see if we are listening. */
-        /* fail_if_condition(e, pn_transport_condition(pn_event_transport(e))); */
+        /* On server, ignore errors from dummy connections used to test if we are listening. */
+        if (a->connection_mode != SERVER) {
+            fail_if_condition(e, pn_transport_condition(pn_event_transport(e)));
+        }
         break;
 
     case PN_CONNECTION_REMOTE_CLOSE:

--- a/exec/quiver-arrow-qpid-proton-cpp.cpp
+++ b/exec/quiver-arrow-qpid-proton-cpp.cpp
@@ -34,6 +34,7 @@
 #include <proton/value.hpp>
 #include <proton/version.h>
 #include <proton/receiver_options.hpp>
+#include <proton/transport.hpp>
 
 #include <algorithm>
 #include <assert.h>
@@ -119,6 +120,10 @@ struct handler : public proton::messaging_handler {
         }
     }
 
+    void on_receiver_open(proton::receiver& r) override {
+        r.open(proton::receiver_options().credit_window(credit_window));
+    }
+
     void on_sendable(proton::sender& s) override {
         assert (operation == "send");
 
@@ -174,6 +179,13 @@ struct handler : public proton::messaging_handler {
             if (connection_mode == "server") {
                 listener.stop();
             }
+        }
+    }
+
+    void on_transport_error(proton::transport& t) override {
+        // On server ignore errors from dummy connections to see if we are listening.
+        if (connection_mode != "server") {
+            on_error(t.error());
         }
     }
 };


### PR DESCRIPTION
- in server mode, ignore transport errors to allow for "are-you-ready" test connections
- set credit on incoming as well as outgoing links