### PR TITLE
Update to Qpid JMS 0.24.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -43,7 +43,7 @@
     <!-- Client Dependencies for Quiver -->
     <activemq-version>5.15.0</activemq-version>
     <artemis-version>2.1.0</artemis-version>
-    <qpid-jms-version>0.23.0</qpid-jms-version>
+    <qpid-jms-version>0.24.0</qpid-jms-version>
     <vertx-proton-version>3.4.2</vertx-proton-version>
     <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
 


### PR DESCRIPTION
Update to v0.24.0 to capture updates for thread leaks and deps on new Netty rev with Epoll fixes etc.