### PR TITLE
Update ActiveMQ and Vert.X client versions

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,10 +41,10 @@
     <slf4j-version>1.7.25</slf4j-version>
 
     <!-- Client Dependencies for Quiver -->
-    <activemq-version>5.15.2</activemq-version>
-    <artemis-version>2.3.0</artemis-version>
+    <activemq-version>5.15.3</activemq-version>
+    <artemis-version>2.4.0</artemis-version>
     <qpid-jms-version>0.29.0</qpid-jms-version>
-    <vertx-proton-version>3.5.0</vertx-proton-version>
+    <vertx-proton-version>3.5.1</vertx-proton-version>
     <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
 
     <!-- Maven Plugin Versions for this Project -->


### PR DESCRIPTION
Update to 5.15.3 for ActiveMQ, 2.4.0 for Artemis and 3.5.1 for Vert.x