### PR TITLE
Workaround ActiveMQ 5.x client not seeing URI provided to JNDI

### DIFF
--- a/java/quiver-jms-driver/src/main/java/net/ssorj/quiver/QuiverArrowJms.java
+++ b/java/quiver-jms-driver/src/main/java/net/ssorj/quiver/QuiverArrowJms.java
@@ -56,6 +56,7 @@ public class QuiverArrowJms {
 
         Hashtable<Object, Object> env = new Hashtable<Object, Object>();
         env.put("connectionFactory.ConnectionFactory", url);
+        env.put("brokerURL", url);
         env.put("queue.queueLookup", path);
 
         Context context = new InitialContext(env);;


### PR DESCRIPTION
Use the ActiveMQ BrokerURL property in the JNDI env to account for the client not reading the URI from the connection factory value.  This allow the URI to be configured and lets the user not use the default failover URI which seems to have an 80% cost on performance with Artemis brokers (depending on disk speed of the user).