### PR TITLE
Added support for target throughput benchmarks in Java

### DIFF
--- a/impls/README.md
+++ b/impls/README.md
@@ -44,6 +44,7 @@ Implementations must process the following positional arguments.
     [10] credit-window     Size of credit window to maintain
     [11] transaction-size  Size of transaction batches; 0 for no transactions
     [12] flags             Comma-separated list of named tokens
+    [13] target            Target throughput in msg/sec; 0 to disable. Java only
 
 If an implementation does not support a particular `connection-mode`
 or `channel-mode`, for instance `server`, it should raise an error at

--- a/python/quiver/arrow.py
+++ b/python/quiver/arrow.py
@@ -193,6 +193,7 @@ class QuiverArrowCommand(Command):
             str(self.credit_window),
             str(self.transaction_size),
             self.flags,
+            str(self.target),
         ]
 
         assert None not in args, args
@@ -328,6 +329,7 @@ class QuiverArrowCommand(Command):
                 "body_size": self.body_size,
                 "credit_window": self.credit_window,
                 "transaction_size": self.transaction_size,
+                "target": self.target,
                 "timeout": self.timeout,
             },
             "results": {

--- a/python/quiver/common.py.in
+++ b/python/quiver/common.py.in
@@ -180,6 +180,9 @@ class Command(object):
         self.parser.add_argument("--transaction-size", metavar="COUNT",
                                  help="Transfer batches of COUNT messages inside transactions; 0 to disable",
                                  default="0")
+        self.parser.add_argument("--target", metavar="COUNT",
+                                 help="Set a target throughput in msg/sec; 0 to disable. Java only",
+                                 default="0")
         self.parser.add_argument("--durable", action="store_true",
                                  help="Require persistent store-and-forward transfers")
         self.parser.add_argument("--timeout", metavar="SECONDS",
@@ -202,6 +205,7 @@ class Command(object):
         self.body_size = self.parse_int_with_unit(self.args.body_size)
         self.credit_window = self.parse_int_with_unit(self.args.credit)
         self.transaction_size = self.parse_int_with_unit(self.args.transaction_size)
+        self.target = self.parse_int_with_unit(self.args.target)
         self.durable = self.args.durable
         self.timeout = self.parse_int_with_unit(self.args.timeout)
 

--- a/python/quiver/pair.py
+++ b/python/quiver/pair.py
@@ -117,6 +117,7 @@ class QuiverPairCommand(Command):
             "--body-size", self.args.body_size,
             "--credit", self.args.credit,
             "--transaction-size", self.args.transaction_size,
+            "--target", self.args.target,
             "--timeout", self.args.timeout,
             "--output", self.output_dir,
         ]


### PR DESCRIPTION
It adds the support for target throughput tests to allow resources and/or latencies 
comparisons between versions that can sustain very different max throughputs.