### PR TITLE
Allow vertx-proton to use native transports

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,15 +41,21 @@
     <slf4j-version>1.7.25</slf4j-version>
 
     <!-- Client Dependencies for Quiver -->
-    <activemq-version>5.15.4</activemq-version>
+    <activemq-version>5.15.5</activemq-version>
     <artemis-version>2.6.2</artemis-version>
-    <qpid-jms-version>0.35.0</qpid-jms-version>
+    <qpid-jms-version>0.36.0</qpid-jms-version>
     <vertx-proton-version>3.5.3</vertx-proton-version>
     <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
+
+    <!-- Netty Version that is used to grab native transport libraries -->
+    <netty-version>4.1.28.Final</netty-version>
 
     <!-- Maven Plugin Versions for this Project -->
     <maven-compiler-plugin-version>3.5.1</maven-compiler-plugin-version>
     <maven-assembly-plugin-version>2.6</maven-assembly-plugin-version>
+
+    <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
+    <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
   </properties>
 
   <issueManagement>
@@ -98,6 +104,18 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-proton</artifactId>
         <version>${vertx-proton-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty-version}</version>
+        <classifier>${netty-transport-native-epoll-classifier}</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <version>${netty-version}</version>
+        <classifier>${netty-transport-native-kqueue-classifier}</classifier>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>

--- a/java/quiver-vertx-proton/pom.xml
+++ b/java/quiver-vertx-proton/pom.xml
@@ -35,6 +35,16 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-proton</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>${netty-transport-native-epoll-classifier}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>${netty-transport-native-kqueue-classifier}</classifier>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/quiver-vertx-proton/src/main/java/net/ssorj/quiver/QuiverArrowVertxProton.java
+++ b/java/quiver-vertx-proton/src/main/java/net/ssorj/quiver/QuiverArrowVertxProton.java
@@ -39,6 +39,7 @@ import org.apache.qpid.proton.amqp.messaging.Data;
 import org.apache.qpid.proton.message.Message;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.proton.ProtonClient;
 import io.vertx.proton.ProtonConnection;
 import io.vertx.proton.ProtonReceiver;
@@ -103,9 +104,9 @@ public class QuiverArrowVertxProton {
         final int portNumber = Integer.parseInt(port);
 
         CountDownLatch completionLatch = new CountDownLatch(1);
-        Vertx vertx = Vertx.vertx();
-        ProtonClient client = ProtonClient.create(vertx);
+        Vertx vertx = Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
 
+        ProtonClient client = ProtonClient.create(vertx);
         client.connect(host, portNumber, res -> {
                 if (res.succeeded()) {
                     ProtonConnection connection = res.result();


### PR DESCRIPTION
Adds in the dependencies and code changes to enabled native transports
in the vertx-proton driver (Epoll and KQueue).

Update ActiveMQ dep to latest 5.15.5 release
Update Qpid JMS to 0.36.0