### PR TITLE
Timeout hack

### DIFF
--- a/impls/quiver-arrow-qpid-proton-c.c
+++ b/impls/quiver-arrow-qpid-proton-c.c
@@ -342,8 +342,9 @@ void run(struct arrow *a) {
 }
 
 bool find_flag(const char* want, const char* flags) {
+    if (!flags) return false;
     size_t len = strlen(want);
-    const char* found = strstr(want, flags);
+    const char* found = strstr(flags, want);
     /* Return true only if what we found is ',' delimited or at start/end of flags */
     return (found &&
             (found == flags || *(found-1) == ',') &&


### PR DESCRIPTION
This is based on master and has a hard-coded 2s timeout. It passes and fails as expected with the following command lines:
Times out:
```
> quiver --impl c --peer-to-peer --messages 10000000 //
impls/quiver-arrow-qpid-proton-c.c:325: timeout expired 2.000000
impls/quiver-arrow-qpid-proton-c.c:206: PN_TRANSPORT_CLOSED: proton:io: Connection reset by peer - disconnected 127.0.0.1:5672 (connection aborted)
quiver-arrow: Error: Sender exited with code 1
quiver-arrow: Error: Receiver exited with code 1
```
Completes normally
```
> quiver --impl c --peer-to-peer --messages 10000 //
<normal output>
```