### PR TITLE
Update Qpid JMS and ActiveMQ client library versions

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,9 +41,9 @@
     <slf4j-version>1.7.25</slf4j-version>
 
     <!-- Client Dependencies for Quiver -->
-    <activemq-version>5.15.6</activemq-version>
+    <activemq-version>5.15.8</activemq-version>
     <artemis-version>2.6.3</artemis-version>
-    <qpid-jms-version>0.37.0</qpid-jms-version>
+    <qpid-jms-version>0.38.0</qpid-jms-version>
     <vertx-proton-version>3.5.4</vertx-proton-version>
     <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
 


### PR DESCRIPTION
Qpid JMS to 0.38.0 and ActiveMQ to 5.15.8