### PR TITLE
Update vertx-proton version to 3.6.0 for latest performance updates.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,7 +44,7 @@
     <activemq-version>5.15.8</activemq-version>
     <artemis-version>2.6.3</artemis-version>
     <qpid-jms-version>0.38.0</qpid-jms-version>
-    <vertx-proton-version>3.5.4</vertx-proton-version>
+    <vertx-proton-version>3.6.0</vertx-proton-version>
     <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
 
     <!-- Netty Version that is used to grab native transport libraries -->


### PR DESCRIPTION
pulls in latest vertx-proton which uses updated proton-j and has fixes and performance improvements