### PR TITLE
Minor improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ QPID_PROTON_CPP_ENABLED := \
 	$(shell PYTHONPATH=python scripts/check-cpp-header "proton/message.hpp" 1> /dev/null 2>&1 && echo yes || echo no)
 QPID_PROTON_PYTHON_ENABLED := \
 	$(shell PYTHONPATH=python scripts/check-python3-import "proton" 1> /dev/null 2>&1 && echo yes || echo no)
+QPID_PROTON_GO_ENABLED := \
+	$(shell go doc "qpid.apache.org/electron" 1> /dev/null 2>&1 && echo yes || echo no)
 
 ifneq (${QPID_PROTON_PYTHON_ENABLED},yes)
         $(warning Qpid Proton Python is required to build Quiver)
@@ -57,6 +59,7 @@ $(info QPID_MESSAGING_PYTHON_ENABLED=${QPID_MESSAGING_PYTHON_ENABLED})
 $(info QPID_PROTON_C_ENABLED=${QPID_PROTON_C_ENABLED})
 $(info QPID_PROTON_CPP_ENABLED=${QPID_PROTON_CPP_ENABLED})
 $(info QPID_PROTON_PYTHON_ENABLED=${QPID_PROTON_PYTHON_ENABLED})
+$(info QPID_PROTON_GO_ENABLED=${QPID_PROTON_GO_ENABLED})
 
 BIN_SOURCES := $(shell find bin -type f -name \*.in)
 BIN_TARGETS := ${BIN_SOURCES:%.in=build/%}
@@ -101,6 +104,10 @@ endif
 
 ifeq (${QPID_PROTON_CPP_ENABLED},yes)
 TARGETS += build/quiver/impls/quiver-arrow-qpid-proton-cpp
+endif
+
+ifeq (${QPID_PROTON_GO_ENABLED},yes)
+TARGETS += build/quiver/impls/quiver-arrow-qpid-electron-go
 endif
 
 CCFLAGS := -g -Os -std=c++11 -lstdc++ -lpthread
@@ -198,6 +205,11 @@ build/quiver/impls/quiver-arrow-qpid-proton-cpp: impls/quiver-arrow-qpid-proton-
 build/quiver/impls/quiver-arrow-qpid-messaging-cpp: impls/quiver-arrow-qpid-messaging-cpp.cpp
 	@mkdir -p ${@D}
 	${CXX} $< -o $@ ${CCFLAGS} -lqpidmessaging -lqpidtypes
+
+force:	      # `go build` will check all dependencies
+build/quiver/impls/quiver-arrow-qpid-electron-go: force
+	@mkdir -p ${@D}
+	go build -o $@ impls/quiver-arrow-qpid-electron-go.go
 
 # XXX Use a template for the java rules
 

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ clean:
 build: ${TARGETS} build/prefix.txt
 	scripts/smoke-test
 
+.PHONY: force
+force:
+
 .PHONY: install
 install: build
 	scripts/install-files build/bin ${DESTDIR}$$(cat build/prefix.txt)/bin
@@ -136,7 +139,11 @@ test: build
 	quiver-test
 
 .PHONY: big-test
-big-test: test test-fedora test-ubuntu
+big-test: test-interop test test-fedora test-ubuntu
+
+.PHONY: test-interop
+test-interop: build
+	scripts/test-interop
 
 .PHONY: test-centos
 test-centos:

--- a/impls/README.md
+++ b/impls/README.md
@@ -114,7 +114,7 @@ confirm their creation.
 
 ### Messages
 
-Implementations must give each message a unique ID to aid debugging.
+Implementations must give each message a unique string ID to aid debugging.
 They must also set an application property named `SendTime` containing
 a `long` representing the send time in milliseconds.
 

--- a/impls/quiver-arrow-qpid-electron-go.go
+++ b/impls/quiver-arrow-qpid-electron-go.go
@@ -1,0 +1,241 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"qpid.apache.org/amqp"
+	"qpid.apache.org/electron"
+)
+
+func fail(format string, arg ...interface{}) {
+	fmt.Fprintf(os.Stderr, "%s: %s\n", filepath.Base(os.Args[0]), fmt.Sprintf(format, arg...))
+	fmt.Fprintln(os.Stderr, os.Args[1:])
+	os.Exit(1)
+}
+
+func failIfErr(err error) {
+	if err != nil {
+		fail("%v", err)
+	}
+}
+
+type Arrow struct {
+	connectionMode, channelMode string
+	operation                   string
+	id, netAddr, path           string
+	count                       int
+	bodySize, creditWindow      int
+	durable                     bool
+
+	container  electron.Container
+	connection electron.Connection
+	done       bool
+}
+
+// Handle delivery outcomes on the sender.
+// Close connection on error or completion.
+func (a *Arrow) outcomes(out chan electron.Outcome) {
+	for i := 0; i < a.count; i++ {
+		select {
+		case o := <-out:
+			if o.Status != electron.Accepted {
+				fail("Unexpected delivery outcome: %v", o)
+			}
+		case <-a.connection.Done():
+			fail("Not enough outcomes %v < %v", i, a.count)
+		}
+	}
+	a.connection.Close(nil)
+}
+
+// Convert Go time.Time into milliseconds since Unix Epoch.
+func now() int64 { return time.Now().UnixNano() / int64(time.Millisecond) }
+
+// Act as a sender
+func (a *Arrow) sender(s electron.Sender) {
+	out := make(chan electron.Outcome, a.creditWindow)
+	go a.outcomes(out)
+	body := strings.Repeat("x", int(a.bodySize))
+	props := make(map[string]interface{})
+	for i := 0; i < a.count; i++ {
+		failIfErr(s.Error())
+		msg := amqp.NewMessageWith(body)
+		id := i + 1
+		msg.SetMessageId(strconv.Itoa(id))
+		msg.SetDurable(a.durable)
+		t := now()
+		props["SendTime"] = t // time.Time encodes as AMQP timestamp
+		msg.SetApplicationProperties(props)
+		fmt.Printf("%v,%v\n", id, t)
+		s.SendAsync(msg, out, nil) // May block for credit. Errors reported via outcomes
+	}
+	a.done = true
+	<-a.connection.Done() // Wait for outcomes() to close the connection
+}
+
+// Act as a receiver
+func (a *Arrow) receiver(r electron.Receiver) {
+	for i := 0; i < a.count; i++ {
+		rm, err := r.Receive()
+		failIfErr(err)
+		rm.Accept()
+		m := rm.Message
+		if t, ok := m.ApplicationProperties()["SendTime"]; ok {
+			fmt.Printf("%v,%v,%v\n", m.MessageId(), t, now())
+		} else {
+			fail("No SendTime property in %v", m)
+		}
+	}
+	a.done = true
+	a.connection.Close(nil)
+}
+
+// Passively accept incoming endpoints.
+func (a *Arrow) passive() {
+	for in := range a.connection.Incoming() {
+		switch in := in.(type) {
+
+		case *electron.IncomingSender:
+			go a.sender(in.Accept().(electron.Sender))
+
+		case *electron.IncomingReceiver:
+			in.SetPrefetch(true)
+			in.SetCapacity(a.creditWindow)
+			go a.receiver(in.Accept().(electron.Receiver))
+
+		default:
+			in.Accept() // Accept connection and sessions unconditionally
+		}
+	}
+}
+
+// Actively initiate outgoing endpoints
+func (a *Arrow) active() {
+	switch a.operation {
+	case "send":
+		s, err := a.connection.Sender(electron.Target(a.path), electron.AtLeastOnce())
+		failIfErr(err)
+		a.sender(s)
+	case "receive":
+		var r electron.Receiver
+		r, err := a.connection.Receiver(electron.Source(a.path), electron.Prefetch(true), electron.Capacity(a.creditWindow))
+		failIfErr(err)
+		a.receiver(r)
+	default:
+		fail("Bad operation: %v", a.operation)
+	}
+}
+
+func (a *Arrow) connected() {
+	switch a.channelMode {
+	case "active":
+		a.active()
+	case "passive":
+		a.passive()
+	default:
+		fail("Bad channel mode %v", a.channelMode)
+	}
+}
+
+func (a *Arrow) run() {
+	a.container = electron.NewContainer(a.id)
+	switch a.connectionMode {
+	case "client":
+		c, err := a.container.Dial("tcp", a.netAddr, electron.SASLAllowedMechs("ANONYMOUS"))
+		failIfErr(err)
+		a.connection = c
+		a.connected()
+	case "server":
+		l, err := net.Listen("tcp", a.netAddr)
+		failIfErr(err)
+		defer l.Close()
+		for !a.done { // May get dummy probe connections
+			a.connection, err = a.container.Accept(l,
+				electron.Server(), electron.SASLAllowedMechs("ANONYMOUS"))
+			failIfErr(err)
+			a.connected()
+		}
+
+	default:
+		fail("bad connection mode %v", a.connectionMode)
+	}
+}
+
+type kwargs map[string]string
+
+func parseArgs() kwargs {
+	kw := make(map[string]string)
+	for _, arg := range os.Args[1:] {
+		kv := strings.SplitN(arg, "=", 2)
+		kw[kv[0]] = kv[1]
+	}
+	return kw
+}
+
+func (kw kwargs) Int(k string) int {
+	n, err := strconv.Atoi(kw[k])
+	if err != nil {
+		fail("\"%v=%v\" not integer: %v", k, kw[k], err)
+	}
+	return n
+}
+
+func (kw kwargs) Bool(k string) bool {
+	b, err := strconv.ParseBool(kw[k])
+	if err != nil {
+		fail("\"%v=%v\" not boolean: %v", k, kw[k], err)
+	}
+	return b
+}
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Printf("Qpid Electron Go")
+		os.Exit(0)
+	}
+
+	kwargs := parseArgs()
+
+	if n := kwargs.Int("transaction-size"); n > 0 {
+		fail("Transactions not supported")
+	}
+
+	a := Arrow{
+		connectionMode: kwargs["connection-mode"],
+		channelMode:    kwargs["channel-mode"],
+		operation:      kwargs["operation"],
+		id:             kwargs["id"],
+		netAddr:        fmt.Sprintf("%v:%v", kwargs["host"], kwargs["port"]),
+		path:           kwargs["path"],
+		count:          kwargs.Int("count"),
+		bodySize:       kwargs.Int("body-size"),
+		creditWindow:   kwargs.Int("credit-window"),
+		durable:        kwargs.Bool("durable"),
+	}
+	a.run()
+}

--- a/impls/quiver-arrow-qpid-proton-c.c
+++ b/impls/quiver-arrow-qpid-proton-c.c
@@ -29,6 +29,7 @@
 #include <proton/sasl.h>
 #include <proton/types.h>
 #include <proton/version.h>
+#include <proton/object.h>
 
 #include <memory.h>
 #include <stdarg.h>
@@ -299,6 +300,12 @@ static bool handle(struct arrow* a, pn_event_t* e) {
 
         if (pn_link_is_sender(link)) {
             // Message acknowledged
+            if (PN_ACCEPTED != pn_delivery_remote_state(delivery)) {
+                // Not accepted: rejected, released or modified.
+                pn_string_t *s = pn_string(NULL);
+                pn_inspect(delivery, s);
+                FAIL("bad delivery: %s", pn_string_get(s));
+            }
 
             pn_delivery_settle(delivery);
 

--- a/python/quiver/common.py.in
+++ b/python/quiver/common.py.in
@@ -79,6 +79,7 @@ _Impl("arrow", "qpid-jms", aliases=["jms"])
 _Impl("arrow", "qpid-messaging-cpp", "arrow")
 _Impl("arrow", "qpid-messaging-python", "arrow")
 _Impl("arrow", "qpid-proton-cpp", aliases=["cpp"], peer_to_peer=True)
+_Impl("arrow", "qpid-electron-go", aliases=["go"], peer_to_peer=True)
 _Impl("arrow", "qpid-proton-c", aliases=["c"], peer_to_peer=True)
 _Impl("arrow", "qpid-proton-python", aliases=["python", "py"], peer_to_peer=True)
 _Impl("arrow", "rhea", aliases=["javascript", "js"], peer_to_peer=True)
@@ -142,6 +143,7 @@ arrow implementations:
   qpid-messaging-python           Client mode only
   qpid-proton-c (c)               The default implementation
   qpid-proton-cpp (cpp)
+  qpid-electron-go [go]
   qpid-proton-python (python, py)
   rhea (javascript, js)
   vertx-proton (java)             Client mode only

--- a/python/quiver/pair.py
+++ b/python/quiver/pair.py
@@ -72,6 +72,8 @@ class QuiverPairCommand(Command):
                                  help="An alias for --arrow")
         self.parser.add_argument("--peer-to-peer", action="store_true",
                                  help="Connect the sender directly to the receiver in server mode")
+        self.parser.add_argument("--send-url", metavar="URL",
+                                 help="Use a separate URL for sending")
 
         self.add_common_test_arguments()
         self.add_common_tool_arguments()
@@ -121,8 +123,11 @@ class QuiverPairCommand(Command):
 
         args += ["--output", self.output_dir]
 
-        sender_args = ["quiver-arrow", "send", self.url, "--impl", self.sender_impl.name] + args
-        receiver_args = ["quiver-arrow", "receive", self.url, "--impl", self.receiver_impl.name] + args
+        recv_url = self.url
+        send_url = self.args.send_url or self.url
+
+        sender_args = ["quiver-arrow", "send", send_url, "--impl", self.sender_impl.name] + args
+        receiver_args = ["quiver-arrow", "receive", recv_url, "--impl", self.receiver_impl.name] + args
 
         if self.peer_to_peer:
             receiver_args += ["--server", "--passive"]

--- a/python/quiver/tests.py
+++ b/python/quiver/tests.py
@@ -69,6 +69,10 @@ def test_arrow_qpid_proton_cpp(session):
     raise TestSkipped("Disabled: https://github.com/ssorj/quiver/issues/51")
     _test_arrow("qpid-proton-cpp")
 
+def test_arrow_qpid_proton_go(session):
+    raise TestSkipped("Disabled: https://github.com/ssorj/quiver/issues/51")
+    _test_arrow("qpid-proton-go")
+
 def test_arrow_qpid_proton_python(session):
     _test_arrow("qpid-proton-python")
 

--- a/scripts/test-interop
+++ b/scripts/test-interop
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from plano import *
+
+def main():
+    enable_logging(level="warn")
+    impls = ["c", "python", "cpp"]
+    pairs = [(s,r) for s in impls for r in impls]
+    # This requires a router or broker to be running
+    for s, r in pairs:
+        cmd = "quiver --peer-to-peer -m 10 --sender %s --receiver %s /x" % (s, r)
+        print("==== %s" % cmd)
+        try:
+            call(cmd, quiet=True)
+        except:
+            pass
+    # TODO aconway 2018-11-01: use --peer-to-peer for this test, the C++ binding
+    # has problems running in passive receiver mode.
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/scripts/test-interop
+++ b/scripts/test-interop
@@ -22,7 +22,7 @@ from plano import *
 
 def main():
     enable_logging(level="warn")
-    impls = ["c", "python", "cpp"]
+    impls = ["c", "python", "cpp", "go"]
     pairs = [(s,r) for s in impls for r in impls]
     # This requires a router or broker to be running
     for s, r in pairs:


### PR DESCRIPTION
The --send-url addition is a convenience for the common case of running a pair test where the sender and receiver should be using different URLs. There are other ways it could be expressed - e.g. an optional second positional argument. Your call if you want to change it.