### PR TITLE
Define -std=c99, _BSD_SOURCE, _POSIX_C_SOURCE 200112L

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ TARGETS += build/quiver/impls/quiver-arrow-qpid-proton-cpp
 endif
 
 CCFLAGS := -g -Os -std=c++11 -lstdc++ -lpthread
-CFLAGS  := -g -Os
+CFLAGS  := -g -Os -std=c99
 
 .PHONY: default
 default: build

--- a/impls/quiver-arrow-qpid-proton-c.c
+++ b/impls/quiver-arrow-qpid-proton-c.c
@@ -19,6 +19,9 @@
  *
  */
 
+#define _BSD_SOURCE
+#define _POSIX_C_SOURCE 200112L
+
 #include <proton/codec.h>
 #include <proton/delivery.h>
 #include <proton/engine.h>

--- a/impls/quiver-arrow-qpid-proton-c.c
+++ b/impls/quiver-arrow-qpid-proton-c.c
@@ -20,6 +20,7 @@
  */
 
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _POSIX_C_SOURCE 200112L
 
 #include <proton/codec.h>


### PR DESCRIPTION
This is necessary for clean compilation on gcc 4.8.5. Errors and warnings
printed without this include

```
impls/quiver-arrow-qpid-proton-c.c:411:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < kwargc; i++) {
     ^
impls/quiver-arrow-qpid-proton-c.c:411:5: note: use option -std=c99 or -std=gnu99 to compile your code
```

```
cc impls/quiver-arrow-qpid-proton-c.c -o build/quiver/impls/quiver-arrow-qpid-proton-c -g -Os -std=c99 -lqpid-proton -lqpid-proton-proactor
impls/quiver-arrow-qpid-proton-c.c: In function ‘now’:
impls/quiver-arrow-qpid-proton-c.c:119:21: error: storage size of ‘t’ isn’t known
     struct timespec t;
```

```
impls/quiver-arrow-qpid-proton-c.c:430:9: warning: implicit declaration of function ‘strsep’ [-Wimplicit-function-declaration]
         kwargv[i][0] = strsep(&arg, "=");
```