### PR TITLE
netty dependency management update

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -43,9 +43,7 @@
     <qpid-jms-version>0.48.0</qpid-jms-version>
     <vertx-proton-version>3.8.5</vertx-proton-version>
     <geronimo.jms.2.spec.version>1.0-alpha-2</geronimo.jms.2.spec.version>
-
-    <!-- Netty Version that is used to grab native transport libraries -->
-    <netty-version>4.1.28.Final</netty-version>
+    <netty-version>4.1.45.Final</netty-version>
 
     <!-- Maven Plugin Versions for this Project -->
     <maven-compiler-plugin-version>3.8.1</maven-compiler-plugin-version>
@@ -103,18 +101,6 @@
         <version>${vertx-proton-version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${netty-version}</version>
-        <classifier>${netty-transport-native-epoll-classifier}</classifier>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>${netty-version}</version>
-        <classifier>${netty-transport-native-kqueue-classifier}</classifier>
-      </dependency>
-      <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-jms_2.0_spec</artifactId>
         <version>${geronimo.jms.2.spec.version}</version>
@@ -133,6 +119,73 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty-version}</version>
+        <classifier>${netty-transport-native-epoll-classifier}</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <version>${netty-version}</version>
+        <classifier>${netty-transport-native-kqueue-classifier}</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns</artifactId>
+        <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-dns</artifactId>
+        <version>${netty-version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,10 +30,6 @@
     Quiver is a performance testing tool for various AMQP 1.0 clients
   </description>
 
-  <prerequisites>
-    <maven>3.0.4</maven>
-  </prerequisites>
-
   <properties>
     <source-version>1.8</source-version>
     <target-version>1.8</target-version>


### PR DESCRIPTION
@tabish121 mentioned some issues he had recently, which turned out to be due to mismatched Netty dependency versions.

This happened because the segment https://github.com/ssorj/quiver/blob/0eca49cdb04fe0c4accffd56be05b8f10b4ffb44/java/pom.xml#L109-L120 is in the parent pom and manages the version of the netty-transport-native-epoll and netty-transport-native-kqueue, for use by the vertx-proton module where they aren't otherwise used/included by default and so are explicitly added. However, since that definition is in the parent pom it also manages the version of those modules when used in e.g the artemis and qpid-jms client modules as well. It however *does not* manage the other Netty modules those clients use, hence the potential for mismatches.

Either we should probably manage all the Netty modules the various clients use to align them all, per this PR, or we should move the above down to the vertx-proton module so it doesn't affect the others.