### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ the given address.
 
 ## Examples
 
-### Running Quiver with ActiveMQ
+### Running Quiver with ActiveMQ classic
 
     [Configure ActiveMQ for anonymous connections and AMQP]
     $ <instance-dir>/bin/activemq start


### PR DESCRIPTION
make it clear ActiveMQ refers to 'classic'